### PR TITLE
Specified the version of the yargs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "read": "latest",
     "sprintf-js": "latest",
     "underscore": "latest",
-    "yargs": "latest"
+    "yargs": "1.0.15"
   },
   "devDependencies": {
     "grunt": "latest",


### PR DESCRIPTION
Specified the version of the **yargs** dependency. Reverting to the previous release, since the latest release contains an error.
